### PR TITLE
More adaptations for new enum API

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_enum.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_enum.rb
@@ -29,13 +29,13 @@ class SorbetRails::ModelPlugins::ActiveRecordEnum < SorbetRails::ModelPlugins::B
         class_method: true,
       )
 
-      enum_call = ActiveRecordOverrides.instance.get_enum_call(@model_class, enum_name.to_sym)
-      if enum_call.nil?
+      enum_options = ActiveRecordOverrides.instance.get_enum_call(@model_class, enum_name.to_sym)
+      if enum_options.nil?
         puts "Error: unable to find enum call for enum #{enum_name}, model #{self.model_class_name}"
         next
       end
 
-      enum_prefix = enum_call[:_prefix]
+      enum_prefix = enum_options[:prefix]
       prefix =
         if enum_prefix == true
           "#{enum_name}_"
@@ -44,7 +44,7 @@ class SorbetRails::ModelPlugins::ActiveRecordEnum < SorbetRails::ModelPlugins::B
         else
           ''
         end
-      enum_suffix = enum_call[:_suffix]
+      enum_suffix = enum_options[:suffix]
       suffix =
         if enum_suffix == true
           "_#{enum_name}"

--- a/lib/sorbet-rails/rails_mixins/active_record_overrides.rb
+++ b/lib/sorbet-rails/rails_mixins/active_record_overrides.rb
@@ -11,17 +11,10 @@ class ActiveRecordOverrides
     @enum_calls = {}
   end
 
-  def store_enum_call(klass, kwargs)
+  def store_enum_call(klass, name, values)
     class_name = klass.name
     @enum_calls[class_name] ||= {}
-    # modeling the logic in
-    # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/enum.rb#L152
-    kwargs.each do |name, values|
-      next if ::ActiveRecord::Enum::SR_ENUM_KEYWORDS.include?(name)
-
-      # calling dup is required, because Rails internally mutates `kwargs` (the args you passed to `enum`)
-      @enum_calls[class_name][name] = kwargs.dup
-    end
+    @enum_calls[class_name][name] = values.dup
   end
 
   def get_enum_call(klass, enum_sym)
@@ -53,7 +46,7 @@ module ::ActiveRecord::Enum
   ]
 
   def _define_enum(name, values, **options)
-    ActiveRecordOverrides.instance.store_enum_call(self, options)
+    ActiveRecordOverrides.instance.store_enum_call(self, name, values)
     old_enum(name, values, **options)
   end
 

--- a/lib/sorbet-rails/rails_mixins/active_record_overrides.rb
+++ b/lib/sorbet-rails/rails_mixins/active_record_overrides.rb
@@ -14,7 +14,7 @@ class ActiveRecordOverrides
   def store_enum_call(klass, name, options)
     class_name = klass.name
     @enum_calls[class_name] ||= {}
-    @enum_calls[class_name][name] = options
+    @enum_calls[class_name][name] = options.dup
   end
 
   def get_enum_call(klass, enum_sym)

--- a/lib/sorbet-rails/rails_mixins/active_record_overrides.rb
+++ b/lib/sorbet-rails/rails_mixins/active_record_overrides.rb
@@ -11,10 +11,10 @@ class ActiveRecordOverrides
     @enum_calls = {}
   end
 
-  def store_enum_call(klass, name, values)
+  def store_enum_call(klass, name, options)
     class_name = klass.name
     @enum_calls[class_name] ||= {}
-    @enum_calls[class_name][name] = values.dup
+    @enum_calls[class_name][name] = options
   end
 
   def get_enum_call(klass, enum_sym)
@@ -46,7 +46,7 @@ module ::ActiveRecord::Enum
   ]
 
   def _define_enum(name, values, **options)
-    ActiveRecordOverrides.instance.store_enum_call(self, name, values)
+    ActiveRecordOverrides.instance.store_enum_call(self, name, options)
     old_enum(name, values, **options)
   end
 


### PR DESCRIPTION
After cutting over the new enum API (https://github.com/TandaHQ/payaus/pull/26975), running `rake rails_rbi:models` for a model with an enum defined in it would complain about an enum not being defined and try to remove some of the method signatures related to the enum.

![image](https://github.com/TandaHQ/sorbet-rails/assets/703/e2fa54c5-6f79-482e-b74e-dc26f6e883ad)

This PR makes a couple of small changes for the generator to record the enums when they are defined and work with the new option names. It no longer supports the deprecated options (`_prefix`, etc.).

~~This works with plain enums, but I think it will need some additional changes to support enums with options (`prefix`, `scopes`, etc.).~~

Have pointed this at payaus branch to test it out, and it seems to work: https://github.com/TandaHQ/payaus/pull/27143