### PR TITLE
Make `ActionController::Helpers#helpers` method untyped

### DIFF
--- a/lib/sorbet-rails/helper_rbi_formatter.rb
+++ b/lib/sorbet-rails/helper_rbi_formatter.rb
@@ -38,7 +38,7 @@ class SorbetRails::HelperRbiFormatter
       @parlour.root.create_module('ActionController::Helpers') do |mod|
         mod.create_method(
           'helpers',
-          return_type: "T.all(#{@helpers.join(', ')})"
+          return_type: "T.untyped"
         )
       end
     end


### PR DESCRIPTION
In our Rails codebase we've been having performance issues with Sorbet where it will take 30-50 seconds to typecheck the codebase.

I isolated the performance issue to a call to the `ActionController::Helpers#helpers` method which creates a `T.all` with all of the helpers in the application. We have a tonne of helpers which leads to performance issues when trying to call a helper method off `helpers`

### Without `ActionController::Helpers#helpers` sig set to `T.untyped`
<img width="462" alt="image" src="https://github.com/TandaHQ/sorbet-rails/assets/13454550/a7c2f6e0-1659-48ed-bca1-a8f54b82ecaf">

### With `ActionController::Helpers#helpers` sig set to `T.untyped`
<img width="463" alt="image" src="https://github.com/TandaHQ/sorbet-rails/assets/13454550/0a367fe0-2208-4786-a2a1-338dfd042d61">

This PR updates the helpers RBI generator to just make the return type `T.untyped` as the performance impact on typechecking isn't worth it.