### PR TITLE
Fix crash when checking if through reflection is polymorphic

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_assoc.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_assoc.rb
@@ -188,6 +188,8 @@ class SorbetRails::ModelPlugins::ActiveRecordAssoc < SorbetRails::ModelPlugins::
 
   sig { params(reflection: T.untyped).returns(T.nilable(T::Boolean)) }
   def polymorphic_assoc?(reflection)
+    return if reflection.nil
+
     reflection.through_reflection ?
       polymorphic_assoc?(reflection.source_reflection) :
       reflection.polymorphic?


### PR DESCRIPTION
Had this error when generating RBI for a model
<img width="663" alt="image" src="https://github.com/user-attachments/assets/e9ce91e3-1f15-42c9-8b42-78327a617b77">

The issue was here: 
https://github.com/TandaHQ/sorbet-rails/blob/70782c2f6c0e2c2d04c773f5ab977b26ac2d3bf5/lib/sorbet-rails/model_plugins/active_record_assoc.rb#L192-L193

The reflection doesn't have a "source_reflection" and isn't polymorphic, so the recursive call ends up with a `NoMethodError`
<img width="811" alt="image" src="https://github.com/user-attachments/assets/d26086a6-18fc-46ec-a352-6f563e842ddb">

Guarding for `nil` seems appropriate here as the reflection would not be polymorphic in this case and generates the RBI file as expected.