### PR TITLE
Address `.connection` deprecation warning

### DIFF
--- a/lib/sorbet-rails/model_column_utils.rb
+++ b/lib/sorbet-rails/model_column_utils.rb
@@ -29,9 +29,13 @@ module SorbetRails::ModelColumnUtils
 
   sig { params(column_def: T.untyped).returns(ColumnType) }
   def type_for_column_def(column_def)
-    cast_type = ActiveRecord::Base.connection.respond_to?(:lookup_cast_type_from_column) ?
-      ActiveRecord::Base.connection.lookup_cast_type_from_column(column_def) :
-      column_def.cast_type
+    cast_type = ActiveRecord::Base.with_connection do |connection|
+      if connection.respond_to?(:lookup_cast_type_from_column)
+        connection.lookup_cast_type_from_column(column_def)
+      else
+        column_def.cast_type
+      end
+    end
 
     array_type = false
     if column_def.try(:array?)


### PR DESCRIPTION
Addresses a deprecation warning when regenerating model RBIs by replacing use of `ActiveRecord::Base.connection` with `ActiveRecord::Base.with_connection`.

Ref: rails/rails#51230