### PR TITLE
Update sorbet rails generated name scope RBI params

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_named_scope.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_named_scope.rb
@@ -33,7 +33,8 @@ class SorbetRails::ModelPlugins::ActiveRecordNamedScope < SorbetRails::ModelPlug
         method_name.to_s,
         parameters: [
           Parameter.new("*args", type: "T.untyped"),
-        ],
+          Parameter.new("**_arg1", type: "T.untyped")
+        ]
       )
     end
   end


### PR DESCRIPTION
Updates params for named scopes generated by sorbet-rails. This matches the args generated by tapioca to avoid conflicts in the case a gem defines scopes for models