### PR TITLE
Add support for aliased attributes

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -28,23 +28,27 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
         next # handled by the ActiveRecordSerializedAttribute plugin
       else
         column_type = type_for_column_def(column_def)
-        attribute_module_rbi.create_method(
-          column_name.to_s,
-          return_type: column_type.to_s,
-        )
-        attribute_module_rbi.create_method(
-          "#{column_name}=",
-          parameters: [
-            Parameter.new("value", type: value_type_for_attr_writer(column_type))
-          ],
-          return_type: nil,
-        )
+        column_name_and_aliases(column_name).each do |name|
+          attribute_module_rbi.create_method(
+            name.to_s,
+            return_type: column_type.to_s,
+          )
+          attribute_module_rbi.create_method(
+            "#{name}=",
+            parameters: [
+              Parameter.new("value", type: value_type_for_attr_writer(column_type))
+            ],
+            return_type: nil,
+          )
+        end
       end
 
-      attribute_module_rbi.create_method(
-        "#{column_name}?",
-        return_type: "T::Boolean",
-      )
+      column_name_and_aliases(column_name).each do |name|
+        attribute_module_rbi.create_method(
+          "#{name}?",
+          return_type: "T::Boolean",
+        )
+      end
     end
   end
 

--- a/lib/sorbet-rails/model_plugins/active_record_attribute.rb
+++ b/lib/sorbet-rails/model_plugins/active_record_attribute.rb
@@ -115,17 +115,19 @@ class SorbetRails::ModelPlugins::ActiveRecordAttribute < SorbetRails::ModelPlugi
       return_type = "String"
       return_type = "T.nilable(#{return_type})" if nilable_column
 
-      attribute_module_rbi.create_method(
-        column_name.to_s,
-        return_type: return_type,
-      )
-      attribute_module_rbi.create_method(
-        "#{column_name}=",
-        parameters: [
-          Parameter.new("value", type: assignable_type)
-        ],
-        return_type: nil,
-      )
+      column_name_and_aliases(column_name).each do |name|
+        attribute_module_rbi.create_method(
+          name.to_s,
+          return_type: return_type,
+        )
+        attribute_module_rbi.create_method(
+          "#{name}=",
+          parameters: [
+            Parameter.new("value", type: assignable_type)
+          ],
+          return_type: nil,
+        )
+      end
     end
   end
 

--- a/lib/sorbet-rails/model_plugins/base.rb
+++ b/lib/sorbet-rails/model_plugins/base.rb
@@ -44,5 +44,12 @@ module SorbetRails::ModelPlugins
         Object
       end
     end
+
+    sig { params(column_name: String).returns(T::Array[String]) }
+    def column_name_and_aliases(column_name)
+      @model_class.attribute_aliases.each_with_object([column_name]) do |(alias_name, target_name), names|
+        names << alias_name if target_name == column_name
+      end
+    end
   end
 end


### PR DESCRIPTION
Includes attribute aliases when generating signatures of attribute methods.

Currently, generating the RBI file for a model generates signatures for the attribute reader and writer methods as well as a predicate for presence of the attribute. Using [`alias_attribute`](https://edgeapi.rubyonrails.org/classes/ActiveModel/AttributeMethods/ClassMethods.html#method-i-alias_attribute) to alias the attribute under a different name generates the same set of methods under the name of the alias, but signatures for this methods are not generated automatically.

This update iterates over the attributes aliases, if there are any, and generates signatures for these methods as well.

I skipped adding this behavior to the typed variants on enums for the time being.