### PR TITLE
Use `fetch_cast_type` instead of `cast_type`

### DIFF
--- a/lib/sorbet-rails/model_column_utils.rb
+++ b/lib/sorbet-rails/model_column_utils.rb
@@ -33,7 +33,7 @@ module SorbetRails::ModelColumnUtils
       if connection.respond_to?(:lookup_cast_type_from_column)
         connection.lookup_cast_type_from_column(column_def)
       else
-        column_def.cast_type
+        column_def.fetch_cast_type(connection)
       end
     end
 

--- a/lib/sorbet-rails/model_column_utils.rb
+++ b/lib/sorbet-rails/model_column_utils.rb
@@ -32,8 +32,10 @@ module SorbetRails::ModelColumnUtils
     cast_type = ActiveRecord::Base.with_connection do |connection|
       if connection.respond_to?(:lookup_cast_type_from_column)
         connection.lookup_cast_type_from_column(column_def)
-      else
+      elsif column_def.respond_to?(:fetch_cast_type)
         column_def.fetch_cast_type(connection)
+      else
+        column_def.cast_type
       end
     end
 


### PR DESCRIPTION
Generating model RBIs does not work on Rails Edge since `cast_type` became protected.

ref: rails/rails#54348

(Looks like this is only a short-term fix for current Rails behavior until 8.1 is released.)