### PR TITLE
Fix signatures for ActiveStorage association methods

### DIFF
--- a/lib/sorbet-rails/model_plugins/active_storage_methods.rb
+++ b/lib/sorbet-rails/model_plugins/active_storage_methods.rb
@@ -30,7 +30,7 @@ class SorbetRails::ModelPlugins::ActiveStorageMethods < SorbetRails::ModelPlugin
   def create_has_one_methods(assoc_name, mod)
     mod.create_method(
       assoc_name,
-      return_type: 'T.nilable(ActiveStorage::Attached::One)'
+      return_type: 'ActiveStorage::Attached::One'
     )
 
     mod.create_method(
@@ -46,7 +46,7 @@ class SorbetRails::ModelPlugins::ActiveStorageMethods < SorbetRails::ModelPlugin
   def create_has_many_methods(assoc_name, mod)
     mod.create_method(
       assoc_name,
-      return_type: 'T.nilable(ActiveStorage::Attached::Many)'
+      return_type: 'ActiveStorage::Attached::Many'
     )
 
     mod.create_method(


### PR DESCRIPTION
The signatures generated for ActiveStorage associations (defined by `has_one_attached` and `has_many_attached`) have a nilable return type, but these association methods never return `nil`. They always return an instance of `ActiveStorage::Attached::One` or `ActiveStorage::Attached::Many`.

https://github.com/rails/rails/blob/4256e620570bf1dc86a597618065ec18a1efa9df/activestorage/lib/active_storage/attached/model.rb#L111-L126

https://github.com/rails/rails/blob/4256e620570bf1dc86a597618065ec18a1efa9df/activestorage/lib/active_storage/attached/model.rb#L213-L230