### PR TITLE
(fix) Rails 8.2.0 patch

### DIFF
--- a/lib/sorbet-rails/routes_rbi_formatter.rb
+++ b/lib/sorbet-rails/routes_rbi_formatter.rb
@@ -58,6 +58,13 @@ class SorbetRails::RoutesRbiFormatter
     ])
   end
 
+  sig { params(routes: T.untyped).void }
+  def footer(routes)
+    # No-op method for Rails 8.2+ compatibility
+    # Rails 8.2 calls footer() at the end of format_routes
+    nil
+  end
+
   sig { returns(String) }
   def result
     @parlour.rbi


### PR DESCRIPTION
## Description of changes

Adds a `footer` method to `RoutesRbiFormatter` for Rails 8.2+ compatibility.

Rails 8.2+ calls `footer()` at the end of `format_routes` (see https://github.com/rails/rails/pull/55752). When running `bin/rails routes` or generating route type definitions with Rails 8.2+, users will encounter:

  `NoMethodError: undefined method 'footer' for #SorbetRails::RoutesRbiFormatter`

Added an empty `footer` method with proper Sorbet signature to satisfy the Rails formatter interface. This avoids the need for a monkey patch to suppress the error.

## History

The `format_routes` method has called `formatter.footer(routes)` since 2013, but Rails' own `Sheet` formatter didn't implement this method until PR #55752 (September 2025). This suggests formatters could previously omit the method, but Rails 8.2+ now requires it.